### PR TITLE
Moved metadata to setup.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ python-license: library/LICENSE.txt
 
 library/README.rst: README.md
 	pandoc --from=markdown --to=rst -o library/README.rst README.md
+	echo "" >> library/README.rst
+	cat library/CHANGELOG.txt >> library/README.rst
 
 library/LICENSE.txt: LICENSE
 	cp LICENSE library/LICENSE.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-LIBRARY_VERSION=$(shell cat library/setup.py | grep version | awk -F"'" '{print $$2}')
-LIBRARY_NAME=$(shell cat library/setup.py | grep name | awk -F"'" '{print $$2}')
+LIBRARY_VERSION=$(shell cat library/setup.cfg | grep version | awk -F" = " '{print $$2}')
+LIBRARY_NAME=$(shell cat library/setup.cfg | grep name | awk -F" = " '{print $$2}')
 
 .PHONY: usage install uninstall
 usage:
@@ -42,8 +42,6 @@ python-license: library/LICENSE.txt
 
 library/README.rst: README.md
 	pandoc --from=markdown --to=rst -o library/README.rst README.md
-	echo "" >> library/README.rst
-	cat library/CHANGELOG.txt >> library/README.rst
 
 library/LICENSE.txt: LICENSE
 	cp LICENSE library/LICENSE.txt

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-LIBRARY_VERSION=`cat library/setup.py | grep version | awk -F"'" '{print $2}'`
-LIBRARY_NAME=`cat library/setup.py | grep name | awk -F"'" '{print $2}'`
+LIBRARY_VERSION=`cat library/setup.cfg | grep version | awk -F" = " '{print $2}'`
+LIBRARY_NAME=`cat library/setup.cfg | grep name | awk -F" = " '{print $2}'`
 
 printf "$LIBRARY_NAME $LIBRARY_VERSION Python Library: Installer\n\n"
 

--- a/library/setup.cfg
+++ b/library/setup.cfg
@@ -1,7 +1,30 @@
+# -*- coding: utf-8 -*-
 [metadata]
+name = {{LIBNAME}}
+version = 0.0.1
+author = Philip Howard
+author_email = phil@pimoroni.com
+description = {{DESCRIPTION}}
+long_description = file: README.rst
+keywords = Raspberry Pi
+url = https://www.pimoroni.com
+project_urls =
+	GitHub=https://www.github.com/pimoroni/{{LIBNAME}}-python
+license = MIT
 # This includes the license file(s) in the wheel.
 # https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_files = LICENSE.txt
+classifiers =
+	Development Status :: 4 - Beta
+	Operating System :: POSIX :: Linux
+	License :: OSI Approved :: MIT License
+	Intended Audience :: Developers
+	Programming Language :: Python :: 2.6
+	Programming Language :: Python :: 2.7
+	Programming Language :: Python :: 3
+	Topic :: Software Development
+	Topic :: Software Development :: Libraries
+	Topic :: System :: Hardware
 
 [flake8]
 exclude =

--- a/library/setup.py
+++ b/library/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# -*- coding: utf-8 -*-
 """
 Copyright (c) 2016 Pimoroni
 
@@ -22,33 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
-classifiers = ['Development Status :: 4 - Beta',
-               'Operating System :: POSIX :: Linux',
-               'License :: OSI Approved :: MIT License',
-               'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.6',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3',
-               'Topic :: Software Development',
-               'Topic :: System :: Hardware']
+from setuptools import setup
 
 setup(
-    name='{{LIBNAME}}',
-    version='0.0.1',
-    author='Philip Howard',
-    author_email='phil@pimoroni.com',
-    description="""{{DESCRIPTION}}""",
-    long_description=open('README.rst').read() + '\n' + open('CHANGELOG.txt').read(),
-    license='MIT',
-    keywords='Raspberry Pi',
-    url='http://www.pimoroni.com',
-    project_urls={'GitHub': 'https://www.github.com/pimoroni/{{LIBNAME}}-python'},
-    classifiers=classifiers,
     packages=['{{LIBNAME}}'],
     install_requires=[]
 )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-LIBRARY_VERSION=`cat library/setup.py | grep version | awk -F"'" '{print $2}'`
-LIBRARY_NAME=`cat library/setup.py | grep name | awk -F"'" '{print $2}'`
+LIBRARY_VERSION=`cat library/setup.cfg | grep version | awk -F" = " '{print $2}'`
+LIBRARY_NAME=`cat library/setup.cfg | grep name | awk -F" = " '{print $2}'`
 
 printf "$LIBRARY_NAME $LIBRARY_VERSION Python Library: Uninstaller\n\n"
 


### PR DESCRIPTION
This change moves the majority of package metadata to setup.cfg where it's somewhat cleaner and easier to parse.

It also drops the legacy fallback to `distutils.core`.

Finally, it concatenates the `CHANGELOG.txt` contents onto `README.rst` so that `setup.py` doesn't need to do slightly shonky things.