### PR TITLE
Use pkg_resources.parse_version directly.

### DIFF
--- a/library/setup.py
+++ b/library/setup.py
@@ -22,14 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from setuptools import setup, __version__, version
+from setuptools import setup, __version__
+from pkg_resources import parse_version
 
-minimum_version = version.pkg_resources.parse_version('30.4.0')
+minimum_version = parse_version('30.4.0')
 
-if version.pkg_resources.parse_version(__version__) < minimum_version:
+if parse_version(__version__) < minimum_version:
     raise RuntimeError("Package setuptools must be at least version {}".format(minimum_version))
 
 setup(
     packages=['{{LIBNAME}}'],
-    install_requires=['setuptools>='.format(minimum_version)]
+    install_requires=['setuptools>={}'.format(minimum_version)]
 )


### PR DESCRIPTION
This should reduce the risk for breakage when setuptools stops using pkg_resources itself in the `setuptools.version` module.

The gist is that lots of pkg_resources functionality is being added to Python (3.7 and 3.8) in importlib (and backported in https://pypi.org/project/importlib-metadata/ and https://pypi.org/project/importlib_resources/). I don't know all the details but I would be seriously surprised if pkg_resources' days wouldn't be counted.

In theory there is already a better implementation for the version comparison that pkg_resources and setuptools already use internally, which is the [packaging](https://github.com/pypa/packaging/) library, that both vendor under `setuptools.extern.packaging` and `pkg_resources.extern.packaging`.

The import looks like this instead:

```python
from setuptools.extern.packaging import version

assert version.parse('40') < version.parse('41')
```

Looking back, the "packaging" library was [vendored in setuptools 8.0](https://setuptools.readthedocs.io/en/latest/history.html#id461) in December 2014 (!) and is used as the [default version comparison method since then](https://github.com/pypa/setuptools/commit/170657b68f4b92e7e1bf82f5e19a831f5744af67). IIRC only Debian Jessie ships with an older setuptools version. Stretch and Buster have it.
