### PR TITLE
Raspberry Pi OS Bookworm + Pep 668

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -35,7 +35,7 @@ jobs:
           make build
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RELEASE_FILE }}
           path: dist/

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,16 +10,15 @@ jobs:
   test:
     name: linting & spelling
     runs-on: ubuntu-latest
-
     env:
       TERM: xterm-256color
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python '3,11'
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -33,3 +33,7 @@ jobs:
       - name: Run Code Checks
         run: |
           make check
+
+      - name: Run Bash Code Checks
+        run: |
+          make shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ endif
 	@echo "deploy:       build and upload to PyPi"
 	@echo "tag:          tag the repository with the current version\n"
 
+version:
+	@hatch version
+
 install:
 	./install.sh --unstable
 
@@ -47,7 +50,7 @@ pytest:
 nopost:
 	@bash check.sh --nopost
 
-tag:
+tag: version
 	git tag -a "v${LIBRARY_VERSION}" -m "Version ${LIBRARY_VERSION}"
 
 build: check

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ uninstall:
 
 dev-deps:
 	python3 -m pip install -r requirements-dev.txt
-	sudo apt install dos2unix
+	sudo apt install dos2unix shellcheck
 
 check:
 	@bash check.sh
+
+shellcheck:
+	shellcheck *.sh
 
 qa:
 	tox -e qa

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # __TITLE__
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/pimoroni/PROJECT_NAME-python/test.yml?branch=main)](https://github.com/pimoroni/PROJECT_NAME-python/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/github/pimoroni/PROJECT_NAME-python/badge.svg?branch=master)](https://coveralls.io/github/pimoroni/PROJECT_NAME-python?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/pimoroni/PROJECT_NAME-python/badge.svg?branch=main)](https://coveralls.io/github/pimoroni/PROJECT_NAME-python?branch=main)
 [![PyPi Package](https://img.shields.io/pypi/v/PROJECT_NAME.svg)](https://pypi.python.org/pypi/PROJECT_NAME)
 [![Python Versions](https://img.shields.io/pypi/pyversions/PROJECT_NAME.svg)](https://pypi.python.org/pypi/PROJECT_NAME)
 

--- a/check.sh
+++ b/check.sh
@@ -6,6 +6,7 @@ NOPOST=$1
 LIBRARY_NAME=`hatch project metadata name`
 LIBRARY_VERSION=`hatch version | awk -F "." '{print $1"."$2"."$3}'`
 POST_VERSION=`hatch version | awk -F "." '{print substr($4,0,length($4))}'`
+TERM=${TERM:="xterm-256color"}
 
 success() {
 	echo -e "$(tput setaf 2)$1$(tput sgr0)"

--- a/check.sh
+++ b/check.sh
@@ -3,9 +3,9 @@
 # This script handles some basic QA checks on the source
 
 NOPOST=$1
-LIBRARY_NAME=`hatch project metadata name`
-LIBRARY_VERSION=`hatch version | awk -F "." '{print $1"."$2"."$3}'`
-POST_VERSION=`hatch version | awk -F "." '{print substr($4,0,length($4))}'`
+LIBRARY_NAME=$(hatch project metadata name)
+LIBRARY_VERSION=$(hatch version | awk -F "." '{print $1"."$2"."$3}')
+POST_VERSION=$(hatch version | awk -F "." '{print substr($4,0,length($4))}')
 TERM=${TERM:="xterm-256color"}
 
 success() {
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	*)
 		if [[ $1 == -* ]]; then
-			printf "Unrecognised option: $1\n";
+			printf "Unrecognised option: %s\n" "$1";
 			exit 1
 		fi
 		POSITIONAL_ARGS+=("$1")
@@ -40,8 +40,7 @@ done
 inform "Checking $LIBRARY_NAME $LIBRARY_VERSION\n"
 
 inform "Checking for trailing whitespace..."
-grep -IUrn --color "[[:blank:]]$" --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO
-if [[ $? -eq 0 ]]; then
+if grep -IUrn --color "[[:blank:]]$" --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=PKG-INFO; then
     warning "Trailing whitespace found!"
     exit 1
 else
@@ -50,8 +49,7 @@ fi
 printf "\n"
 
 inform "Checking for DOS line-endings..."
-grep -lIUrn --color $'\r' --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile
-if [[ $? -eq 0 ]]; then
+if grep -lIUrn --color $'\r' --exclude-dir=dist --exclude-dir=.tox --exclude-dir=.git --exclude=Makefile; then
     warning "DOS line-endings found!"
     exit 1
 else
@@ -60,8 +58,7 @@ fi
 printf "\n"
 
 inform "Checking CHANGELOG.md..."
-cat CHANGELOG.md | grep ^${LIBRARY_VERSION} > /dev/null 2>&1
-if [[ $? -eq 1 ]]; then
+if ! grep "^${LIBRARY_VERSION}" CHANGELOG.md > /dev/null 2>&1; then
     warning "Changes missing for version ${LIBRARY_VERSION}! Please update CHANGELOG.md."
     exit 1
 else
@@ -70,8 +67,7 @@ fi
 printf "\n"
 
 inform "Checking for git tag ${LIBRARY_VERSION}..."
-git tag -l | grep -E "${LIBRARY_VERSION}$"
-if [[ $? -eq 1 ]]; then
+if ! git tag -l | grep -E "${LIBRARY_VERSION}$"; then
     warning "Missing git tag for version ${LIBRARY_VERSION}"
 fi
 printf "\n"

--- a/install.sh
+++ b/install.sh
@@ -301,7 +301,9 @@ for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
-	printf "\"%s\"\n" "$CMD"
+	if [[ ! "$CMD" == printf* ]]; then
+		printf "Running: \"%s\"\n" "$CMD"
+	fi
 	eval "$CMD"
 	check_for_error
 done

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
+PY_VENV_DIR=$RESOURCES_TOP_DIR/venv
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
@@ -12,14 +13,6 @@ FORCE=false
 UNSTABLE=false
 PYTHON="python"
 
-
-venv_check() {
-	PYTHON_BIN=`which $PYTHON`
-	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
-		printf "This script should be run in a virtual Python environment.\n"
-		exit 1
-	fi	       
-}
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
@@ -60,6 +53,28 @@ inform() {
 
 warning() {
 	echo -e "$(tput setaf 1)$1$(tput sgr0)"
+}
+
+venv_check() {
+	PYTHON_BIN=`which $PYTHON`
+	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
+		printf "This script should be run in a virtual Python environment.\n"
+		if confirm "Would you like us to create one for you?"; then
+			if [ ! -f $PY_VENV_DIR/bin/activate ]; then
+				inform "Creating virtual Python environment in $PY_VENV_DIR, please wait...\n"
+				mkdir -p $PY_VENV_DIR
+				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages
+			else
+				inform "Found existing virtual Python environment in $PY_VENV_DIR\n"
+			fi
+			inform "Activating virtual Python environment in $PY_VENV_DIR..."
+			inform "source $PY_VENV_DIR/bin/activate\n"
+			source $PY_VENV_DIR/bin/activate
+
+		else
+			exit 1
+		fi
+	fi
 }
 
 function do_config_backup {
@@ -136,7 +151,7 @@ done
 user_check
 venv_check
 
-if [ ! -f "$PYTHON" ]; then
+if [ ! -f `which $PYTHON` ]; then
 	printf "Python path $PYTHON not found!\n"
 	exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -74,9 +74,11 @@ find_config() {
 }
 
 venv_bash_snippet() {
+	inform "Checking for $VENV_BASH_SNIPPET\n"
 	if [ ! -f $VENV_BASH_SNIPPET ]; then
+		inform "Creating $VENV_BASH_SNIPPET\n"
 		cat << EOF > $VENV_BASH_SNIPPET
-# Add `source $VENV_BASH_SNIPPET` to your ~/.bashrc to activate
+# Add "source $VENV_BASH_SNIPPET" to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
 VENV_DIR="$VENV_DIR"
 if [ ! -f \$VENV_DIR/bin/activate ]; then

--- a/install.sh
+++ b/install.sh
@@ -58,11 +58,6 @@ find_config() {
 		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
 			fatal "Could not find $CONFIG_FILE!"
 		fi
-	else
-		if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
-			warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
-			warning "You might want to fix this!"
-		fi
 	fi
 	inform "Using $CONFIG_FILE in $CONFIG_DIR"
 }

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,8 @@ DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
-PY_VENV_DIR=$HOME/.virtualenvs/pimoroni
+VENV_BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
+VENV_DIR=$HOME/.virtualenvs/pimoroni
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
@@ -56,18 +57,18 @@ warning() {
 }
 
 venv_bash_snippet() {
-	if [ ! -f $BASH_SNIPPET ]; then
-		cat << EOF > $BASH_SNIPPET
+	if [ ! -f $VENV_BASH_SNIPPET ]; then
+		cat << EOF > $VENV_BASH_SNIPPET
 # Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
-PY_VENV_DIR="$PY_VENV_DIR"
-if [ ! -f \$PY_VENV_DIR/bin/activate ]; then
-  printf "Creating user Python environment in \$PY_VENV_DIR, please wait...\n"
-  mkdir -p \$PY_VENV_DIR
-  python3 -m venv --system-site-packages \$PY_VENV_DIR
+VENV_DIR="$VENV_DIR"
+if [ ! -f \$VENV_DIR/bin/activate ]; then
+  printf "Creating user Python environment in \$VENV_DIR, please wait...\n"
+  mkdir -p \$VENV_DIR
+  python3 -m venv --system-site-packages \$VENV_DIR
 fi
 printf " ↓ ↓ ↓ ↓   Hello, we've activated a Python venv for you. To exit, type \"deactivate\".\n"
-source \$PY_VENV_DIR/bin/activate
+source \$VENV_DIR/bin/activate
 EOF
 	fi
 }
@@ -77,17 +78,17 @@ venv_check() {
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
 		printf "This script should be run in a virtual Python environment.\n"
 		if confirm "Would you like us to create one for you?"; then
-			if [ ! -f $PY_VENV_DIR/bin/activate ]; then
-				inform "Creating virtual Python environment in $PY_VENV_DIR, please wait...\n"
-				mkdir -p $PY_VENV_DIR
-				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages Pimoroni
-				venv_bash_snippet()
+			if [ ! -f $VENV_DIR/bin/activate ]; then
+				inform "Creating virtual Python environment in $VENV_DIR, please wait...\n"
+				mkdir -p $VENV_DIR
+				/usr/bin/python3 -m venv $VENV_DIR --system-site-packages
+				venv_bash_snippet
 			else
-				inform "Found existing virtual Python environment in $PY_VENV_DIR\n"
+				inform "Found existing virtual Python environment in $VENV_DIR\n"
 			fi
-			inform "Activating virtual Python environment in $PY_VENV_DIR..."
-			inform "source $PY_VENV_DIR/bin/activate\n"
-			source $PY_VENV_DIR/bin/activate
+			inform "Activating virtual Python environment in $VENV_DIR..."
+			inform "source $VENV_DIR/bin/activate\n"
+			source $VENV_DIR/bin/activate
 
 		else
 			exit 1
@@ -185,7 +186,7 @@ pip_pkg_install toml
 CONFIG_VARS=`$PYTHON - <<EOF
 import toml
 config = toml.load("pyproject.toml")
-p = dict(config['pimoroni'])
+p = dict(config['tool']['pimoroni'])
 # Convert list config entries into bash arrays
 for k, v in p.items():
     v = "'\n\t'".join(v)
@@ -206,7 +207,6 @@ eval $CONFIG_VARS
 
 RESOURCES_DIR=$RESOURCES_TOP_DIR/$LIBRARY_NAME
 UNINSTALLER=$RESOURCES_DIR/uninstall.sh
-BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
 
 RES_DIR_OWNER=`stat -c "%U" $RESOURCES_TOP_DIR`
 

--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ venv_check() {
 check_for_error() {
 	if [ $? -ne 0 ]; then
 		CMD_ERRORS=true
-		warning "^^^ 😬"
+		warning "^^^ 😬 previous command did not exit cleanly!"
 	fi
 }
 
@@ -290,14 +290,18 @@ fi
 
 find_config
 
+printf "\n"
+
 # Run the setup commands from pyproject.toml / tool.pimoroni.commands
 
+inform "Running setup commands...\n"
 for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	CMD="${SETUP_CMDS[$i]}"
 	# Attempt to catch anything that touches config.txt and trigger a backup
 	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
+	printf "\"%s\"\n" "$CMD"
 	eval "$CMD"
 	check_for_error
 done

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
+LIBRARY_NAME=$(grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}')
 CONFIG_FILE=config.txt
 CONFIG_DIR="/boot/firmware"
-DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
+DATESTAMP=$(date "+%Y-%m-%d-%H-%M-%S")
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR="$HOME/Pimoroni"
 VENV_BASH_SNIPPET="$RESOURCES_TOP_DIR/auto_venv.sh"
 VENV_DIR="$HOME/.virtualenvs/pimoroni"
-WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
 FORCE=false
@@ -18,7 +17,7 @@ CMD_ERRORS=false
 
 
 user_check() {
-	if [ $(id -u) -eq 0 ]; then
+	if [ "$(id -u)" -eq 0 ]; then
 		fatal "Script should not be run as root. Try './install.sh'\n"
 	fi
 }
@@ -33,15 +32,6 @@ confirm() {
 		else
 			false
 		fi
-	fi
-}
-
-prompt() {
-	read -r -p "$1 [y/N] " response < /dev/tty
-	if [[ $response =~ ^(yes|y|Y)$ ]]; then
-		true
-	else
-		false
 	fi
 }
 
@@ -79,10 +69,10 @@ find_config() {
 
 venv_bash_snippet() {
 	inform "Checking for $VENV_BASH_SNIPPET\n"
-	if [ ! -f $VENV_BASH_SNIPPET ]; then
+	if [ ! -f "$VENV_BASH_SNIPPET" ]; then
 		inform "Creating $VENV_BASH_SNIPPET\n"
-		mkdir -p $RESOURCES_TOP_DIR
-		cat << EOF > $VENV_BASH_SNIPPET
+		mkdir -p "$RESOURCES_TOP_DIR"
+		cat << EOF > "$VENV_BASH_SNIPPET"
 # Add "source $VENV_BASH_SNIPPET" to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
 VENV_DIR="$VENV_DIR"
@@ -98,21 +88,23 @@ EOF
 }
 
 venv_check() {
-	PYTHON_BIN=`which $PYTHON`
+	PYTHON_BIN=$(which "$PYTHON")
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
 		printf "This script should be run in a virtual Python environment.\n"
 		if confirm "Would you like us to create and/or use a default one?"; then
 			printf "\n"
-			if [ ! -f $VENV_DIR/bin/activate ]; then
+			if [ ! -f "$VENV_DIR/bin/activate" ]; then
 				inform "Creating a new virtual Python environment in $VENV_DIR, please wait...\n"
-				mkdir -p $VENV_DIR
-				/usr/bin/python3 -m venv $VENV_DIR --system-site-packages
+				mkdir -p "$VENV_DIR"
+				/usr/bin/python3 -m venv "$VENV_DIR" --system-site-packages
 				venv_bash_snippet
-				source $VENV_DIR/bin/activate
+				# shellcheck disable=SC1091
+				source "$VENV_DIR/bin/activate"
 			else
 				inform "Activating existing virtual Python environment in $VENV_DIR\n"
-				printf "source $VENV_DIR/bin/activate\n"
-				source $VENV_DIR/bin/activate
+				printf "source \"%s/bin/activate\"\n" "$VENV_DIR"
+				# shellcheck disable=SC1091
+				source "$VENV_DIR/bin/activate"
 			fi
 		else
 			printf "\n"
@@ -134,29 +126,29 @@ function do_config_backup {
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
 		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
-		sudo cp $CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME
-		mkdir -p $RESOURCES_TOP_DIR/config-backups/
-		cp $CONFIG_DIR/$CONFIG_FILE $RESOURCES_TOP_DIR/config-backups/$FILENAME
+		sudo cp "$CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME"
+		mkdir -p "$RESOURCES_TOP_DIR/config-backups/"
+		cp $CONFIG_DIR/$CONFIG_FILE "$RESOURCES_TOP_DIR/config-backups/$FILENAME"
 		if [ -f "$UNINSTALLER" ]; then
-			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG_DIR/$CONFIG_FILE" >> $UNINSTALLER
+			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG_DIR/$CONFIG_FILE" >> "$UNINSTALLER"
 		fi
 	fi
 }
 
 function apt_pkg_install {
-	PACKAGES=()
+	PACKAGES_NEEDED=()
 	PACKAGES_IN=("$@")
 	# Check the list of packages and only run update/install if we need to
 	for ((i = 0; i < ${#PACKAGES_IN[@]}; i++)); do
 		PACKAGE="${PACKAGES_IN[$i]}"
 		if [ "$PACKAGE" == "" ]; then continue; fi
-		printf "Checking for $PACKAGE\n"
-		dpkg -L $PACKAGE > /dev/null 2>&1
+		printf "Checking for %s\n" "$PACKAGE"
+		dpkg -L "$PACKAGE" > /dev/null 2>&1
 		if [ "$?" == "1" ]; then
-			PACKAGES+=("$PACKAGE")
+			PACKAGES_NEEDED+=("$PACKAGE")
 		fi
 	done
-	PACKAGES="${PACKAGES[@]}"
+	PACKAGES="${PACKAGES_NEEDED[*]}"
 	if ! [ "$PACKAGES" == "" ]; then
 		printf "\n"
 		inform "Installing missing packages: $PACKAGES"
@@ -164,10 +156,10 @@ function apt_pkg_install {
 			sudo apt update
 			APT_HAS_UPDATED=true
 		fi
-		sudo apt install -y $PACKAGES
+		sudo apt install -y "$PACKAGES"
 		check_for_error
 		if [ -f "$UNINSTALLER" ]; then
-			echo "apt uninstall -y $PACKAGES" >> $UNINSTALLER
+			echo "apt uninstall -y $PACKAGES" >> "$UNINSTALLER"
 		fi
 	fi
 }
@@ -196,8 +188,8 @@ while [[ $# -gt 0 ]]; do
 		;;
 	*)
 		if [[ $1 == -* ]]; then
-			printf "Unrecognised option: $1\n";
-			printf "Usage: $USAGE\n";
+			printf "Unrecognised option: %s\n" "$1";
+			printf "Usage: %s\n" "$USAGE";
 			exit 1
 		fi
 		POSITIONAL_ARGS+=("$1")
@@ -205,16 +197,16 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-printf "Installing $LIBRARY_NAME...\n\n"
+printf "Installing %s...\n\n" "$LIBRARY_NAME"
 
 user_check
 venv_check
 
-if [ ! -f `which $PYTHON` ]; then
-	fatal "Python path $PYTHON not found!\n"
+if [ ! -f "$(which "$PYTHON")" ]; then
+	fatal "Python path %s not found!\n" "$PYTHON"
 fi
 
-PYTHON_VER=`$PYTHON --version`
+PYTHON_VER=$($PYTHON --version)
 
 inform "Checking Dependencies. Please wait..."
 
@@ -222,7 +214,8 @@ inform "Checking Dependencies. Please wait..."
 
 pip_pkg_install toml
 
-CONFIG_VARS=`$PYTHON - <<EOF
+CONFIG_VARS=$(
+	$PYTHON - <<EOF
 import toml
 config = toml.load("pyproject.toml")
 github_url = config['project']['urls']['GitHub']
@@ -237,32 +230,34 @@ APT_PACKAGES={apt_packages}
 SETUP_CMDS={commands}
 CONFIG_TXT={configtxt}
 """.format(**p))
-EOF`
+EOF
+)
 
+# shellcheck disable=SC2181 # Inlining the above command would be messy
 if [ $? -ne 0 ]; then
 	# This is bad, this should not happen in production!
 	fatal "Error parsing configuration...\n"
 fi
 
-eval $CONFIG_VARS
+eval "$CONFIG_VARS"
 
 RESOURCES_DIR=$RESOURCES_TOP_DIR/$LIBRARY_NAME
 UNINSTALLER=$RESOURCES_DIR/uninstall.sh
 
-RES_DIR_OWNER=`stat -c "%U" $RESOURCES_TOP_DIR`
+RES_DIR_OWNER=$(stat -c "%U" "$RESOURCES_TOP_DIR")
 
 # Previous install.sh scripts were run as root with sudo, which caused
 # the ~/Pimoroni dir to be created with root ownership. Try and fix it.
 if [[ "$RES_DIR_OWNER" == "root" ]]; then
 	warning "\n\nFixing $RESOURCES_TOP_DIR permissions!\n\n"
-	sudo chown -R $USER:$USER $RESOURCES_TOP_DIR
+	sudo chown -R "$USER:$USER" "$RESOURCES_TOP_DIR"
 fi
 
-mkdir -p $RESOURCES_DIR
+mkdir -p "$RESOURCES_DIR"
 
 # Create a stub uninstaller file, we'll try to add the inverse of every
 # install command run to here, though it's not complete.
-cat << EOF > $UNINSTALLER
+cat << EOF > "$UNINSTALLER"
 printf "It's recommended you run these steps manually.\n"
 printf "If you want to run the full script, open it in\n"
 printf "an editor and remove 'exit 1' from below.\n"
@@ -284,15 +279,14 @@ if $UNSTABLE; then
 	pip_pkg_install .
 else
 	inform "Installing stable library from pypi.\n"
-	pip_pkg_install $LIBRARY_NAME
+	pip_pkg_install "$LIBRARY_NAME"
 fi
 
+# shellcheck disable=SC2181 # One of two commands run, depending on --unstable flag
 if [ $? -eq 0 ]; then
 	success "Done!\n"
-	echo "$PYTHON -m pip uninstall $LIBRARY_NAME" >> $UNINSTALLER
+	echo "$PYTHON -m pip uninstall $LIBRARY_NAME" >> "$UNINSTALLER"
 fi
-
-cd $WD
 
 find_config
 
@@ -304,7 +298,7 @@ for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
-	eval $CMD
+	eval "$CMD"
 	check_for_error
 done
 
@@ -319,7 +313,7 @@ for ((i = 0; i < ${#CONFIG_TXT[@]}; i++)); do
 		inform "Adding $CONFIG_LINE to $CONFIG_DIR/$CONFIG_FILE"
 		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG_DIR/$CONFIG_FILE
 		if ! grep -q "^$CONFIG_LINE" $CONFIG_DIR/$CONFIG_FILE; then
-			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG_DIR/$CONFIG_FILE
+			printf "%s \n" "$CONFIG_LINE" | sudo tee --append $CONFIG_DIR/$CONFIG_FILE
 		fi
 	fi
 done
@@ -331,8 +325,8 @@ printf "\n"
 if [ -d "examples" ]; then
 	if confirm "Would you like to copy examples to $RESOURCES_DIR?"; then
 		inform "Copying examples to $RESOURCES_DIR"
-		cp -r examples/ $RESOURCES_DIR
-		echo "rm -r $RESOURCES_DIR" >> $UNINSTALLER
+		cp -r examples/ "$RESOURCES_DIR"
+		echo "rm -r $RESOURCES_DIR" >> "$UNINSTALLER"
 		success "Done!"
 	fi
 fi
@@ -345,8 +339,7 @@ if confirm "Would you like to generate documentation?"; then
 	inform "Installing pdoc. Please wait..."
 	pip_pkg_install pdoc
 	inform "Generating documentation.\n"
-	$PYTHON -m pdoc $LIBRARY_NAME -o $RESOURCES_DIR/docs > /dev/null
-	if [ $? -eq 0 ]; then
+	if $PYTHON -m pdoc "$LIBRARY_NAME" -o "$RESOURCES_DIR/docs" > /dev/null; then
 		inform "Documentation saved to $RESOURCES_DIR/docs"
 		success "Done!"
 	else
@@ -360,13 +353,13 @@ if [ "$CMD_ERRORS" = true ]; then
 	warning "One or more setup commands appear to have failed."
 	printf "This might prevent things from working properly.\n"
 	printf "Make sure your OS is up to date and try re-running this installer.\n"
-	printf "If things still don't work, report this or find help at $GITHUB_URL.\n\n"
+	printf "If things still don't work, report this or find help at %s.\n\n" "$GITHUB_URL"
 else
 	success "\nAll done!"
 fi
 
 printf "If this is your first time installing you should reboot for hardware changes to take effect.\n"
-printf "Find uninstall steps in $UNINSTALLER\n\n"
+printf "Find uninstall steps in %s\n\n" "$UNINSTALLER"
 
 if [ "$CMD_ERRORS" = true ]; then
 	exit 1

--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,8 @@ function apt_pkg_install {
 			sudo apt update
 			APT_HAS_UPDATED=true
 		fi
-		sudo apt install -y "$PACKAGES"
+		# shellcheck disable=SC2086
+		sudo apt install -y $PACKAGES
 		check_for_error
 		if [ -f "$UNINSTALLER" ]; then
 			echo "apt uninstall -y $PACKAGES" >> "$UNINSTALLER"

--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ function do_config_backup {
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
 		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
-		sudo cp "$CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME"
+		sudo cp "$CONFIG_DIR/$CONFIG_FILE" "$CONFIG_DIR/$FILENAME"
 		mkdir -p "$RESOURCES_TOP_DIR/config-backups/"
 		cp $CONFIG_DIR/$CONFIG_FILE "$RESOURCES_TOP_DIR/config-backups/$FILENAME"
 		if [ -f "$UNINSTALLER" ]; then

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,16 @@ USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
 FORCE=false
 UNSTABLE=false
-PYTHON="/usr/bin/python3"
+PYTHON="python"
 
+
+venv_check() {
+	PYTHON_BIN=`which $PYTHON`
+	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
+		printf "This script should be run in a virtual Python environment.\n"
+		exit 1
+	fi	       
+}
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
@@ -126,6 +134,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 user_check
+venv_check
 
 if [ ! -f "$PYTHON" ]; then
 	printf "Python path $PYTHON not found!\n"
@@ -179,6 +188,7 @@ printf "It's recommended you run these steps manually.\n"
 printf "If you want to run the full script, open it in\n"
 printf "an editor and remove 'exit 1' from below.\n"
 exit 1
+source $VIRTUAL_ENV/bin/activate
 EOF
 
 if $UNSTABLE; then

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
-CONFIG=/boot/config.txt
+CONFIG_FILE=config.txt
+CONFIG_DIR="/boot/firmware"
 DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
@@ -56,6 +57,22 @@ warning() {
 	echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
+find_config() {
+	if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
+		CONFIG_DIR="/boot"
+		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE"]; then
+			warning "Could not find $CONFIG_FILE!"
+			exit 1
+		fi
+    else
+        if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
+            warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
+            warning "You might want to fix this!"
+        fi
+	fi
+    inform "Using $CONFIG_FILE in $CONFIG_DIR"
+}
+
 venv_bash_snippet() {
 	if [ ! -f $VENV_BASH_SNIPPET ]; then
 		cat << EOF > $VENV_BASH_SNIPPET
@@ -100,12 +117,12 @@ function do_config_backup {
 	if [ ! $CONFIG_BACKUP == true ]; then
 		CONFIG_BACKUP=true
 		FILENAME="config.preinstall-$LIBRARY_NAME-$DATESTAMP.txt"
-		inform "Backing up $CONFIG to /boot/$FILENAME\n"
-		sudo cp $CONFIG /boot/$FILENAME
+		inform "Backing up $CONFIG_DIR/$CONFIG_FILE to $CONFIG_DIR/$FILENAME\n"
+		sudo cp $CONFIG_DIR/$CONFIG_FILE $CONFIG_DIR/$FILENAME
 		mkdir -p $RESOURCES_TOP_DIR/config-backups/
-		cp $CONFIG $RESOURCES_TOP_DIR/config-backups/$FILENAME
+		cp $CONFIG_DIR/$CONFIG_FILE $RESOURCES_TOP_DIR/config-backups/$FILENAME
 		if [ -f "$UNINSTALLER" ]; then
-			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG" >> $UNINSTALLER
+			echo "cp $RESOURCES_TOP_DIR/config-backups/$FILENAME $CONFIG_DIR/$CONFIG_FILE" >> $UNINSTALLER
 		fi
 	fi
 }
@@ -245,10 +262,12 @@ fi
 
 cd $WD
 
+find_config
+
 for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	CMD="${SETUP_CMDS[$i]}"
-	# Attempt to catch anything that touches /boot/config.txt and trigger a backup
-	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG"* ]] || [[ "$CMD" == *"\$CONFIG"* ]]; then
+	# Attempt to catch anything that touches config.txt and trigger a backup
+	if [[ "$CMD" == *"raspi-config"* ]] || [[ "$CMD" == *"$CONFIG_DIR/$CONFIG_FILE"* ]] || [[ "$CMD" == *"\$CONFIG_DIR/\$CONFIG_FILE"* ]]; then
 		do_config_backup
 	fi
 	eval $CMD
@@ -258,10 +277,10 @@ for ((i = 0; i < ${#CONFIG_TXT[@]}; i++)); do
 	CONFIG_LINE="${CONFIG_TXT[$i]}"
 	if ! [ "$CONFIG_LINE" == "" ]; then
 		do_config_backup
-		inform "Adding $CONFIG_LINE to $CONFIG\n"
-		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG
-		if ! grep -q "^$CONFIG_LINE" $CONFIG; then
-			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG
+		inform "Adding $CONFIG_LINE to $CONFIG_DIR/$CONFIG_FILE\n"
+		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG_DIR/$CONFIG_FILE
+		if ! grep -q "^$CONFIG_LINE" $CONFIG_DIR/$CONFIG_FILE; then
+			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG_DIR/$CONFIG_FILE
 		fi
 	fi
 done

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
-VENV_BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
+VENV_BASH_SNIPPET=$RESOURCES_TOP_DIR/auto_venv.sh
 VENV_DIR=$HOME/.virtualenvs/pimoroni
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
@@ -76,7 +76,7 @@ find_config() {
 venv_bash_snippet() {
 	if [ ! -f $VENV_BASH_SNIPPET ]; then
 		cat << EOF > $VENV_BASH_SNIPPET
-# Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
+# Add `source $VENV_BASH_SNIPPET` to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
 VENV_DIR="$VENV_DIR"
 if [ ! -f \$VENV_DIR/bin/activate ]; then

--- a/install.sh
+++ b/install.sh
@@ -64,13 +64,13 @@ find_config() {
 			warning "Could not find $CONFIG_FILE!"
 			exit 1
 		fi
-    else
-        if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
-            warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
-            warning "You might want to fix this!"
-        fi
+	else
+		if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
+			warning "Oops! It looks like /boot/$CONFIG_FILE is not a link to $CONFIG_DIR/$CONFIG_FILE"
+			warning "You might want to fix this!"
+		fi
 	fi
-    inform "Using $CONFIG_FILE in $CONFIG_DIR"
+	inform "Using $CONFIG_FILE in $CONFIG_DIR"
 }
 
 venv_bash_snippet() {

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,23 @@ warning() {
 	echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
+venv_bash_snippet() {
+	if [ ! -f $BASH_SNIPPET ]; then
+		cat << EOF > $BASH_SNIPPET
+# Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
+# the Pimoroni virtual environment automagically!
+PY_ENV_DIR=~/Pimoroni/venv
+if [ ! -f \$PY_ENV_DIR/bin/activate ]; then
+  printf "Creating user Python environment in \$PY_ENV_DIR, please wait...\n"
+  mkdir -p \$PY_ENV_DIR
+  python3 -m venv --system-site-packages --prompt Pimoroni \$PY_ENV_DIR
+fi
+printf " ↓ ↓ ↓ ↓   Hello, we've activated a Python venv for you. To exit, type \"deactivate\".\n"
+source \$PY_ENV_DIR/bin/activate
+EOF
+	fi
+}
+
 venv_check() {
 	PYTHON_BIN=`which $PYTHON`
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
@@ -63,7 +80,8 @@ venv_check() {
 			if [ ! -f $PY_VENV_DIR/bin/activate ]; then
 				inform "Creating virtual Python environment in $PY_VENV_DIR, please wait...\n"
 				mkdir -p $PY_VENV_DIR
-				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages
+				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages --prompt Pimoroni
+				venv_bash_snippet()
 			else
 				inform "Found existing virtual Python environment in $PY_VENV_DIR\n"
 			fi
@@ -188,6 +206,7 @@ eval $CONFIG_VARS
 
 RESOURCES_DIR=$RESOURCES_TOP_DIR/$LIBRARY_NAME
 UNINSTALLER=$RESOURCES_DIR/uninstall.sh
+BASH_SNIPPET=$RESOURCES_DIR/auto_venv.sh
 
 RES_DIR_OWNER=`stat -c "%U" $RESOURCES_TOP_DIR`
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
 RESOURCES_TOP_DIR=$HOME/Pimoroni
-PY_VENV_DIR=$RESOURCES_TOP_DIR/venv
+PY_VENV_DIR=$HOME/.virtualenvs/pimoroni
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
@@ -60,14 +60,14 @@ venv_bash_snippet() {
 		cat << EOF > $BASH_SNIPPET
 # Add `source $RESOURCES_DIR/auto_venv.sh` to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
-PY_ENV_DIR=~/Pimoroni/venv
-if [ ! -f \$PY_ENV_DIR/bin/activate ]; then
-  printf "Creating user Python environment in \$PY_ENV_DIR, please wait...\n"
-  mkdir -p \$PY_ENV_DIR
-  python3 -m venv --system-site-packages --prompt Pimoroni \$PY_ENV_DIR
+PY_VENV_DIR="$PY_VENV_DIR"
+if [ ! -f \$PY_VENV_DIR/bin/activate ]; then
+  printf "Creating user Python environment in \$PY_VENV_DIR, please wait...\n"
+  mkdir -p \$PY_VENV_DIR
+  python3 -m venv --system-site-packages \$PY_VENV_DIR
 fi
 printf " ↓ ↓ ↓ ↓   Hello, we've activated a Python venv for you. To exit, type \"deactivate\".\n"
-source \$PY_ENV_DIR/bin/activate
+source \$PY_VENV_DIR/bin/activate
 EOF
 	fi
 }
@@ -80,7 +80,7 @@ venv_check() {
 			if [ ! -f $PY_VENV_DIR/bin/activate ]; then
 				inform "Creating virtual Python environment in $PY_VENV_DIR, please wait...\n"
 				mkdir -p $PY_VENV_DIR
-				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages --prompt Pimoroni
+				/usr/bin/python3 -m venv $PY_VENV_DIR --system-site-packages Pimoroni
 				venv_bash_snippet()
 			else
 				inform "Found existing virtual Python environment in $PY_VENV_DIR\n"

--- a/install.sh
+++ b/install.sh
@@ -5,21 +5,21 @@ CONFIG_DIR="/boot/firmware"
 DATESTAMP=`date "+%Y-%m-%d-%H-%M-%S"`
 CONFIG_BACKUP=false
 APT_HAS_UPDATED=false
-RESOURCES_TOP_DIR=$HOME/Pimoroni
-VENV_BASH_SNIPPET=$RESOURCES_TOP_DIR/auto_venv.sh
-VENV_DIR=$HOME/.virtualenvs/pimoroni
+RESOURCES_TOP_DIR="$HOME/Pimoroni"
+VENV_BASH_SNIPPET="$RESOURCES_TOP_DIR/auto_venv.sh"
+VENV_DIR="$HOME/.virtualenvs/pimoroni"
 WD=`pwd`
 USAGE="./install.sh (--unstable)"
 POSITIONAL_ARGS=()
 FORCE=false
 UNSTABLE=false
 PYTHON="python"
+CMD_ERRORS=false
 
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
-		printf "Script should not be run as root. Try './install.sh'\n"
-		exit 1
+		fatal "Script should not be run as root. Try './install.sh'\n"
 	fi
 }
 
@@ -54,15 +54,19 @@ inform() {
 }
 
 warning() {
-	echo -e "$(tput setaf 1)$1$(tput sgr0)"
+	echo -e "$(tput setaf 1)⚠ WARNING:$(tput sgr0) $1"
+}
+
+fatal() {
+	echo -e "$(tput setaf 1)⚠ FATAL:$(tput sgr0) $1"
+	exit 1
 }
 
 find_config() {
 	if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
 		CONFIG_DIR="/boot"
-		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE"]; then
-			warning "Could not find $CONFIG_FILE!"
-			exit 1
+		if [ ! -f "$CONFIG_DIR/$CONFIG_FILE" ]; then
+			fatal "Could not find $CONFIG_FILE!"
 		fi
 	else
 		if [ -f "/boot/$CONFIG_FILE" ] && [ ! -L "/boot/$CONFIG_FILE" ]; then
@@ -77,6 +81,7 @@ venv_bash_snippet() {
 	inform "Checking for $VENV_BASH_SNIPPET\n"
 	if [ ! -f $VENV_BASH_SNIPPET ]; then
 		inform "Creating $VENV_BASH_SNIPPET\n"
+		mkdir -p $RESOURCES_TOP_DIR
 		cat << EOF > $VENV_BASH_SNIPPET
 # Add "source $VENV_BASH_SNIPPET" to your ~/.bashrc to activate
 # the Pimoroni virtual environment automagically!
@@ -96,22 +101,31 @@ venv_check() {
 	PYTHON_BIN=`which $PYTHON`
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
 		printf "This script should be run in a virtual Python environment.\n"
-		if confirm "Would you like us to create one for you?"; then
+		if confirm "Would you like us to create and/or use a default one?"; then
+			printf "\n"
 			if [ ! -f $VENV_DIR/bin/activate ]; then
-				inform "Creating virtual Python environment in $VENV_DIR, please wait...\n"
+				inform "Creating a new virtual Python environment in $VENV_DIR, please wait...\n"
 				mkdir -p $VENV_DIR
 				/usr/bin/python3 -m venv $VENV_DIR --system-site-packages
 				venv_bash_snippet
+				source $VENV_DIR/bin/activate
 			else
-				inform "Found existing virtual Python environment in $VENV_DIR\n"
+				inform "Activating existing virtual Python environment in $VENV_DIR\n"
+				printf "source $VENV_DIR/bin/activate\n"
+				source $VENV_DIR/bin/activate
 			fi
-			inform "Activating virtual Python environment in $VENV_DIR..."
-			inform "source $VENV_DIR/bin/activate\n"
-			source $VENV_DIR/bin/activate
-
 		else
-			exit 1
+			printf "\n"
+			fatal "Please create and/or activate a virtual Python environment and try again!\n"
 		fi
+	fi
+	printf "\n"
+}
+
+check_for_error() {
+	if [ $? -ne 0 ]; then
+		CMD_ERRORS=true
+		warning "^^^ 😬"
 	fi
 }
 
@@ -132,6 +146,7 @@ function do_config_backup {
 function apt_pkg_install {
 	PACKAGES=()
 	PACKAGES_IN=("$@")
+	# Check the list of packages and only run update/install if we need to
 	for ((i = 0; i < ${#PACKAGES_IN[@]}; i++)); do
 		PACKAGE="${PACKAGES_IN[$i]}"
 		if [ "$PACKAGE" == "" ]; then continue; fi
@@ -143,12 +158,14 @@ function apt_pkg_install {
 	done
 	PACKAGES="${PACKAGES[@]}"
 	if ! [ "$PACKAGES" == "" ]; then
-		echo "Installing missing packages: $PACKAGES"
+		printf "\n"
+		inform "Installing missing packages: $PACKAGES"
 		if [ ! $APT_HAS_UPDATED ]; then
 			sudo apt update
 			APT_HAS_UPDATED=true
 		fi
 		sudo apt install -y $PACKAGES
+		check_for_error
 		if [ -f "$UNINSTALLER" ]; then
 			echo "apt uninstall -y $PACKAGES" >> $UNINSTALLER
 		fi
@@ -156,7 +173,9 @@ function apt_pkg_install {
 }
 
 function pip_pkg_install {
+	# A null Keyring prevents pip stalling in the background
 	PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring $PYTHON -m pip install --upgrade "$@"
+	check_for_error
 }
 
 while [[ $# -gt 0 ]]; do
@@ -186,30 +205,33 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
+printf "Installing $LIBRARY_NAME...\n\n"
+
 user_check
 venv_check
 
 if [ ! -f `which $PYTHON` ]; then
-	printf "Python path $PYTHON not found!\n"
-	exit 1
+	fatal "Python path $PYTHON not found!\n"
 fi
 
 PYTHON_VER=`$PYTHON --version`
 
-printf "$LIBRARY_NAME Python Library: Installer\n\n"
-
 inform "Checking Dependencies. Please wait..."
+
+# Install toml and try to read pyproject.toml into bash variables
 
 pip_pkg_install toml
 
 CONFIG_VARS=`$PYTHON - <<EOF
 import toml
 config = toml.load("pyproject.toml")
+github_url = config['project']['urls']['GitHub']
 p = dict(config['tool']['pimoroni'])
 # Convert list config entries into bash arrays
 for k, v in p.items():
     v = "'\n\t'".join(v)
     p[k] = f"('{v}')"
+print(f'GITHUB_URL="{github_url}"')
 print("""
 APT_PACKAGES={apt_packages}
 SETUP_CMDS={commands}
@@ -218,8 +240,8 @@ CONFIG_TXT={configtxt}
 EOF`
 
 if [ $? -ne 0 ]; then
-	warning "Error parsing configuration...\n"
-	exit 1
+	# This is bad, this should not happen in production!
+	fatal "Error parsing configuration...\n"
 fi
 
 eval $CONFIG_VARS
@@ -229,6 +251,8 @@ UNINSTALLER=$RESOURCES_DIR/uninstall.sh
 
 RES_DIR_OWNER=`stat -c "%U" $RESOURCES_TOP_DIR`
 
+# Previous install.sh scripts were run as root with sudo, which caused
+# the ~/Pimoroni dir to be created with root ownership. Try and fix it.
 if [[ "$RES_DIR_OWNER" == "root" ]]; then
 	warning "\n\nFixing $RESOURCES_TOP_DIR permissions!\n\n"
 	sudo chown -R $USER:$USER $RESOURCES_TOP_DIR
@@ -236,6 +260,8 @@ fi
 
 mkdir -p $RESOURCES_DIR
 
+# Create a stub uninstaller file, we'll try to add the inverse of every
+# install command run to here, though it's not complete.
 cat << EOF > $UNINSTALLER
 printf "It's recommended you run these steps manually.\n"
 printf "If you want to run the full script, open it in\n"
@@ -244,19 +270,23 @@ exit 1
 source $VIRTUAL_ENV/bin/activate
 EOF
 
-if $UNSTABLE; then
-	warning "Installing unstable library from source.\n\n"
-else
-	printf "Installing stable library from pypi.\n\n"
-fi
+printf "\n"
 
 inform "Installing for $PYTHON_VER...\n"
+
+# Install apt packages from pyproject.toml / tool.pimoroni.apt_packages
 apt_pkg_install "${APT_PACKAGES[@]}"
+
+printf "\n"
+
 if $UNSTABLE; then
+	warning "Installing unstable library from source.\n"
 	pip_pkg_install .
 else
+	inform "Installing stable library from pypi.\n"
 	pip_pkg_install $LIBRARY_NAME
 fi
+
 if [ $? -eq 0 ]; then
 	success "Done!\n"
 	echo "$PYTHON -m pip uninstall $LIBRARY_NAME" >> $UNINSTALLER
@@ -266,6 +296,8 @@ cd $WD
 
 find_config
 
+# Run the setup commands from pyproject.toml / tool.pimoroni.commands
+
 for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 	CMD="${SETUP_CMDS[$i]}"
 	# Attempt to catch anything that touches config.txt and trigger a backup
@@ -273,19 +305,28 @@ for ((i = 0; i < ${#SETUP_CMDS[@]}; i++)); do
 		do_config_backup
 	fi
 	eval $CMD
+	check_for_error
 done
+
+printf "\n"
+
+# Add the config.txt entries from pyproject.toml / tool.pimoroni.configtxt
 
 for ((i = 0; i < ${#CONFIG_TXT[@]}; i++)); do
 	CONFIG_LINE="${CONFIG_TXT[$i]}"
 	if ! [ "$CONFIG_LINE" == "" ]; then
 		do_config_backup
-		inform "Adding $CONFIG_LINE to $CONFIG_DIR/$CONFIG_FILE\n"
+		inform "Adding $CONFIG_LINE to $CONFIG_DIR/$CONFIG_FILE"
 		sudo sed -i "s/^#$CONFIG_LINE/$CONFIG_LINE/" $CONFIG_DIR/$CONFIG_FILE
 		if ! grep -q "^$CONFIG_LINE" $CONFIG_DIR/$CONFIG_FILE; then
 			printf "$CONFIG_LINE\n" | sudo tee --append $CONFIG_DIR/$CONFIG_FILE
 		fi
 	fi
 done
+
+printf "\n"
+
+# Just a straight copy of the examples/ dir into ~/Pimoroni/board/examples
 
 if [ -d "examples" ]; then
 	if confirm "Would you like to copy examples to $RESOURCES_DIR?"; then
@@ -298,9 +339,12 @@ fi
 
 printf "\n"
 
+# Use pdoc to generate basic documentation from the installed module
+
 if confirm "Would you like to generate documentation?"; then
+	inform "Installing pdoc. Please wait..."
 	pip_pkg_install pdoc
-	printf "Generating documentation.\n"
+	inform "Generating documentation.\n"
 	$PYTHON -m pdoc $LIBRARY_NAME -o $RESOURCES_DIR/docs > /dev/null
 	if [ $? -eq 0 ]; then
 		inform "Documentation saved to $RESOURCES_DIR/docs"
@@ -310,6 +354,22 @@ if confirm "Would you like to generate documentation?"; then
 	fi
 fi
 
-success "\nAll done!"
-inform "If this is your first time installing you should reboot for hardware changes to take effect.\n"
-inform "Find uninstall steps in $UNINSTALLER\n"
+printf "\n"
+
+if [ "$CMD_ERRORS" = true ]; then
+	warning "One or more setup commands appear to have failed."
+	printf "This might prevent things from working properly.\n"
+	printf "Make sure your OS is up to date and try re-running this installer.\n"
+	printf "If things still don't work, report this or find help at $GITHUB_URL.\n\n"
+else
+	success "\nAll done!"
+fi
+
+printf "If this is your first time installing you should reboot for hardware changes to take effect.\n"
+printf "Find uninstall steps in $UNINSTALLER\n\n"
+
+if [ "$CMD_ERRORS" = true ]; then
+	exit 1
+else
+	exit 0
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ ignore = [
     'requirements-dev.txt'
 ]
 
-[pimoroni]
+[tool.pimoroni]
 apt_packages = ["python3-rpi.gpio", "python3-smbus"]
 configtxt = []
 commands = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,6 @@ ignore = [
 ]
 
 [tool.pimoroni]
-apt_packages = ["python3-rpi.gpio", "python3-smbus"]
+apt_packages = ["git"]
 configtxt = []
-commands = []
+commands = ["false"]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff .
+	ruff check .
 	codespell .
 deps =
 	check-manifest

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 	python -m build --no-isolation
 	python -m twine check dist/*
 	isort --check .
-	ruff --format=github .
+	ruff .
 	codespell .
 deps =
 	check-manifest

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 FORCE=false
-LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
+LIBRARY_NAME=$(grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}')
 RESOURCES_DIR=$HOME/Pimoroni/$LIBRARY_NAME
 PYTHON="python"
 
 
 venv_check() {
-	PYTHON_BIN=`which $PYTHON`
+	PYTHON_BIN=$(which $PYTHON)
 	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
 		printf "This script should be run in a virtual Python environment.\n"
 		exit 1
@@ -15,7 +15,7 @@ venv_check() {
 }
 
 user_check() {
-	if [ $(id -u) -eq 0 ]; then
+	if [ "$(id -u)" -eq 0 ]; then
 		printf "Script should not be run as root. Try './uninstall.sh'\n"
 		exit 1
 	fi
@@ -55,17 +55,17 @@ warning() {
 	echo -e "$(tput setaf 1)$1$(tput sgr0)"
 }
 
-printf "$LIBRARY_NAME Python Library: Uninstaller\n\n"
+printf "%s Python Library: Uninstaller\n\n" "$LIBRARY_NAME"
 
 user_check
 venv_check
 
 printf "Uninstalling for Python 3...\n"
-$PYTHON -m pip uninstall $LIBRARY_NAME
+$PYTHON -m pip uninstall "$LIBRARY_NAME"
 
-if [ -d $RESOURCES_DIR ]; then
+if [ -d "$RESOURCES_DIR" ]; then
 	if confirm "Would you like to delete $RESOURCES_DIR?"; then
-		rm -r $RESOURCES_DIR
+		rm -r "$RESOURCES_DIR"
 	fi
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,7 +3,16 @@
 FORCE=false
 LIBRARY_NAME=`grep -m 1 name pyproject.toml | awk -F" = " '{print substr($2,2,length($2)-2)}'`
 RESOURCES_DIR=$HOME/Pimoroni/$LIBRARY_NAME
-PYTHON="/usr/bin/python3"
+PYTHON="python"
+
+
+venv_check() {
+	PYTHON_BIN=`which $PYTHON`
+	if [[ $VIRTUAL_ENV == "" ]] || [[ $PYTHON_BIN != $VIRTUAL_ENV* ]]; then
+		printf "This script should be run in a virtual Python environment.\n"
+		exit 1
+	fi
+}
 
 user_check() {
 	if [ $(id -u) -eq 0 ]; then
@@ -49,6 +58,7 @@ warning() {
 printf "$LIBRARY_NAME Python Library: Uninstaller\n\n"
 
 user_check
+venv_check
 
 printf "Uninstalling for Python 3...\n"
 $PYTHON -m pip uninstall $LIBRARY_NAME


### PR DESCRIPTION
⚠️  Progress / TODO List moved to https://github.com/pimoroni/boilerplate-python/issues/16

# Rationale

Update:

* I have switched to `~/.virtualenvs/pimoroni' as the default virtualenv dir, since this is what `virtualenvwrapper` uses, and thus is one of the search paths used by Visual Studio Code.
* I have raised a PR with Thonny to get this same directory supported there, so we can have some cohesion between CLI, VSCode, Thonny - https://github.com/thonny/thonny/pull/2978

As of RPi OS Bookworm (required for the Raspberry Pi 5) incorporating [Pep 668](https://peps.python.org/pep-0668/), we are required to install Python packages into a virtual environment or "venv".

The TLDR of 668 is twofold -

* Allowing users to affect the system-wide Python installation could lead to broken system packages or a broken system Python environment. Therefore we should not.
* Using a virtual environment allows dependencies to be managed per project, so the chance of conflicting dependencies (one library needs v1.0.0 another needs v2.0.0 for example) is reduced.

Attempting to modify the system Python environment will kick out an error along the lines of:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
  python3-xyz, where xyz is the package you are trying to
  install.
  ```

[Raspberry Pi's own documentation](https://www.raspberrypi.com/documentation/computers/os.html#python-on-raspberry-pi) (linked in this error message on RPi OS) attempts to cover some basic use cases of virtual environments ans shows some per-project and per user patterns you might consider if you're keen to learn.

For most beginners, however, the specifics of setting up a virtual environment are largely meaningless and due to the non-destructive - you might say "virtual" - nature of these environments there is no harm in us stepping in as the arbiter of truth and setting up one by default.

We can do this in a couple of ways:

# Supporting venvs in our Python boilerplate

The changes in *this* PR attempt to detect and (optionally) manage a virtual environment for the user.

The virtual environment we use by default will live in `$HOME/.virtualenvs/pimoroni` and this will be shared across all packages, giving a single common mixed use venv for beginners.

# Providing a simple "manage me a venv" script

It's possible for a user to opt to gloss over the existence of a virtual environment by adding the following lines to `~/.bashrc` - 

```bash
PY_ENV_DIR=$HOME/.virtualenvs/pimoroni
if [ ! -f $PY_ENV_DIR/bin/activate ]; then
  printf "Creating user Python environment in $PY_ENV_DIR, please wait...\n"
  mkdir -p $PY_ENV_DIR
  python3 -m venv --system-site-packages $PY_ENV_DIR
fi
printf " ↓ ↓ ↓ ↓   Hello, we've activated a Python venv for you. To exit, type \"deactivate\".\n"
source $PY_ENV_DIR/bin/activate
```

This will create (if it does not exist) and activate a Python virtual environment automatically any time a bash shell is opened. If the user doesn't want to use it, they can type "deactivate" or switch into another virtual environment just as easily.

The idea behind this is that users who have installed our software, and are set up to use our `$HOME/.virtualenvs/pimoroni` virtual environment don't need to explicitly activate it every time they want to work with our products.

Putting this into `~/.bashrc` automatically would be unwise since:

* It's a little rude, since it's difficult to explain in crystal clear detail just how this will modify the users shell
* It's quite difficult to check if it's already there
* It's difficult to automatically update, should it ever need changing
* We don't know what else is in `~/.bashrc` and how it might (negatively) interact with this snippet
* There are many instances where it doesn't help or take effect; ie: VSCode or Thonny.

But it's probably *useful* for users who really don't want to have to think about virtual environments (much.)

# System Packages

In both cases, since we still rely on apt packages to satisfy some dependencies, we're using `--system-site-packages` to pass through the system Python packages into the virtualenv. This is generally unwise since it introduces packages we can't properly manage into the virtualenv, but for now it permits the use of `gpiozero` + `lgpio` (the latter missing a proper pypi package) and 'libgpiod' (also currently missing a working pypi package),

# What about my precious rpi_ws281x?

In order to run Python code as root within the virtualenv context you need to:

```
sudo --preserve-env=PATH python my_code.py
```

# In conclusion

Many users don't really want to know or care about a per-project virtual Python environment, and just want a close approximation of the old behaviour. This gets us part of the way with the notable exceptions that:

* Running Python code as root is more complicated (see above)
* System-owned Python packages are made available to the virtual environment, but this may cause conflicts between older (RPi OS ships with a 3 year old libgpiod 1.6.3) system packages a newer Pypi packages.
* It's not always obvious how to use a virtual env with a particular IDE, Thonny's UX around venvs- for example - is, confusing.
